### PR TITLE
firefox bug fixes that make firefox almost usable

### DIFF
--- a/public/app/AppView.js
+++ b/public/app/AppView.js
@@ -547,6 +547,9 @@ define([
       if (e.stopPropagation) {
         e.stopPropagation(); // stops the browser from redirecting.
       }
+      if (e.preventDefault) {
+        e.preventDefault(); 
+      }
       
       //if it's a unicode dragging event
       if(window.appView.insertUnicodesView.dragSrcEl != null){

--- a/public/audio_video/AudioVideoEditView.js
+++ b/public/audio_video/AudioVideoEditView.js
@@ -69,8 +69,12 @@ define([
     
     dropAudio: function(e) {
       Utils.debug("Recieved a drop event ");
-      e.stopPropagation();
-//      e.preventDefault();
+      if (e.stopPropagation) {
+        e.stopPropagation(); // stops the browser from redirecting.
+      }
+      if (e.preventDefault) {
+        e.preventDefault(); 
+      }      
       this.classList.remove('halfopacity');
       window.appView.term.addDroppedFiles(e.dataTransfer.files);
       window.appView.term.output('<div>File(s) added!</div>');

--- a/public/authentication/AuthenticationEditView.js
+++ b/public/authentication/AuthenticationEditView.js
@@ -194,6 +194,23 @@ define([
             }                    
           });
         });
+        
+        //wait a bit and load user's dashboard even if they can't replicate, its possible they are running in the CORS lacking web app. TODO remove this if and when we get CORS on iriscouch
+        window.setTimeout( function(){
+          //If the user has an untitled corpus, there is a high chance that their dashboard didn't load because they cant sync with couch but they do have their first local ones, attempt to look it up in their user, and laod it.
+          if(app.get("corpus").get("title").indexOf("Untitled Corpus") >= 0){
+            if(self.model.get("userPrivate").get("mostRecentIds") == undefined){
+              //do nothing because they have no recent ids
+              Utils.debug("User does not have most recent ids, doing nothing.");
+            }else{
+              /*
+               *  Load their last corpus, session, datalist etc
+               */
+              var appids = self.model.get("userPrivate").get("mostRecentIds");
+              window.app.loadBackboneObjectsById(couchConnection, appids);
+            }
+          }
+        },5000);
 
 
         

--- a/public/user/UserWelcomeView.js
+++ b/public/user/UserWelcomeView.js
@@ -266,6 +266,7 @@ define([
                        * Use the corpus just created to log the user into that corpus's couch server
                        */
                       var couchConnection = data.user.corpuses[0];
+                      $('#user-welcome-modal').modal("hide");//users might have unreliable pouches if they do things this early, but on web version they wont get successful callbacks from couch. TODO if and when we get CORS on iriscouch, move this back to after replicate corpus.
                       c.logUserIntoTheirCorpusServer(couchConnection, dataToPost.username, dataToPost.password, function() {
                         Utils.debug("Successfully authenticated user with their corpus server.");
                         //Bring down the views so the user can search locally without pushing to a server.
@@ -274,7 +275,6 @@ define([
                         //save the users' first dashboard so at least they will have it if they close the app.
                         window.setTimeout(function(){
                           window.app.storeCurrentDashboardIdsToLocalStorage();
-                          $('#user-welcome-modal').modal("hide");
                         },10000);
                         
                       });


### PR DESCRIPTION
fixes #356 testing in firefox
- i tried preventing defaults in firefox but stil cannot drag unicode,
- import does drag and show contents, but my edit table doesnt show up
- with the new modal dismiss i can get to my dashboard yay!
- wont be able to sync on firefox until the CORS is working
- drag and drop audio might be working but there is some problems seeing the power user terminal to see if it says no file io

Conclusion: firefox works probably fine if we can debug its events a bit, but it wont work for team use, only offline alone until/if we get our couch server to accept CORS or we find another workaround. 

After our battles with Chrome 20 and Chrome 22 not working, but Chrome 21 working we are starting to seriously consider supporting only Firefox and switching off Chrome entirely. :)
