### PR TITLE
Import from Toolbox format now accommodates metadata and items that begin with any field label 

### DIFF
--- a/backbone_client/import/Import.js
+++ b/backbone_client/import/Import.js
@@ -370,6 +370,9 @@ define([
         callback();
       }
     },
+
+    metadataLines : [],
+
     /**
      * This function takes in a text block, splits it on lines and then
      * takes the first word with a \firstword as the data type/column
@@ -396,15 +399,29 @@ define([
       var currentDatum = -1;
       var header = [];
       var columnhead = "";
-      for(l in lines){
+
+      var firstToolboxField = "";
+
+      /* Looks for the first line of the toolbox data */
+      while(!firstToolboxField && lines.length > 0){
+        var potentialToolBoxFieldMatches = lines[0].match(/^\\[a-zA-Z]+\b/);
+        if(potentialToolBoxFieldMatches && potentialToolBoxFieldMatches.length > 0){
+          firstToolboxField = potentialToolBoxFieldMatches[0];
+        }else{
+          /* remove the line, and put it into the metadata lines */
+          this.metadataLines.push(lines.shift());
+        }
+      }
+
+      for(var l in lines){
         //Its a new row
-        if( lines[l].indexOf("\\ge ") == 0 ){
+        if( lines[l].indexOf(firstToolboxField) == 0 ){
           currentDatum += 1;
           matrix[currentDatum] = {};
-          matrix[currentDatum]["ge"] = lines[l].replace("\\ge ","");;
-          header.push("ge");
+          matrix[currentDatum][firstToolboxField.replace(/\\/g,"")] = lines[l].replace(firstToolboxField,"").trim();
+          header.push(firstToolboxField.replace(/\\/g,""));
         }else{
-          if(currentDatum > 0){
+          if(currentDatum >= 0){
             //If the line starts with \ its a column 
             if(lines[l].match(/^\\/) ){
               var pieces = lines[l].split(/ +/);

--- a/backbone_client/import/ImportEditView.js
+++ b/backbone_client/import/ImportEditView.js
@@ -420,6 +420,13 @@ define( [
         if(this.sessionView){
           this.sessionView.destroy_view();
         }
+        /* put metadata in the session goals */
+        var sessionGoal = this.model.get("session").get("sessionFields").where({
+            label : "goal"
+          })[0];
+        if(sessionGoal){
+          sessionGoal.set("mask", this.model.metadataLines.join("\n") + "\n"+ sessionGoal.get("mask") );
+        }
         this.sessionView = new SessionEditView({
           model : this.model.get("session")
         });


### PR DESCRIPTION
Before, import from Toolbox format assumed that items began with \ge,
but not all toolbox files do this, so now it searches for the first
instance of backslash+alphabetic characters+space and uses this label
to delimit items

Also, material from before this first toolbox label is ignored for the
purposes of the actual data array and instead it's treated as metadata
and added to the "goal" field on import

Fixes #1176
